### PR TITLE
Fix handling for thread recycling of Logs and free space calculation

### DIFF
--- a/microprofile.h
+++ b/microprofile.h
@@ -434,6 +434,7 @@ MICROPROFILE_API uint64_t MicroProfileEnterInternal(MicroProfileToken nToken);
 MICROPROFILE_API void MicroProfileLeaveInternal(MicroProfileToken nToken, uint64_t nTick);
 MICROPROFILE_API void MicroProfileEnter(MicroProfileToken nToken);
 MICROPROFILE_API void MicroProfileLeave();
+MICROPROFILE_API void MicroProfileFence();
 MICROPROFILE_API void MicroProfileEnterGpu(MicroProfileToken nToken, struct MicroProfileThreadLogGpu* pLog);
 MICROPROFILE_API void MicroProfileLeaveGpu(struct MicroProfileThreadLogGpu* pLog);
 MICROPROFILE_API uint32_t MicroProfileTimelineEnterInternal(uint32_t nColor, const char* pStr, int nStrLen, int bIsStaticString);


### PR DESCRIPTION
Issue 1: microprofile.cpp:MicroProfileLogPutEnter

This is computing how much space is left in the buffer: nDistance. The calculation is seeing how many free entries there are "between" nGet and nPut. However, since the buffer is circular, nGet may be greater than or less than nPut. This is attempting to calculate size via "nDistance = (nGet - nNextPos) % MICROPROFILE_BUFFER_SIZE;". Unfortunately, this math doesn't work and will result in the wrong value being calculated. The result of this calculation is that, either, entries will not be put into the log (safe) or it will add to the log when there is no room.

Issue 2:
When MicroProfileFlip process log entries for a thread, it stores the current state of processing in two values: nStackPos and nStackLogEntry. When a thread exits, the log data for that thread is freed up and cached for a future thread. When logging data is cached for reuse, the code is resetting a few of the fields but not all. So, this bug happens because the stack for entries being processed is not empty. The server stack exits ("resetting the log", partially) and then re-using it when it immediately starts back up. The stack was leaking these frames so it looked like they were still there.

The fix is to fully reset the log for the thread so that no data leaks from one thread to another.

Why are we seeing this: in this scenario we stop the server thread and resume it many times. If the log was not fully flushed when that happens, we end up leaking entries. "Most" of the time, this isn't an issue, but it does happen every now and then. It is all up to where the log processing is with respect to the thread recycling.

This is probably not a common scenario for other users, hence why we found it.

Other:

The change added to MicroProfiler to expand the size of the stack introduced iostream dependencies. I have removed these as MicroProfiler uses "printf" currently.

I also added the ability to put a "fence" in the profile log that essentially forces a check to ensure that the state stack is in an expected state (e.g.: empty).