### PR TITLE
Dump file writing fixes

### DIFF
--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -3139,6 +3139,8 @@ void MicroProfileDumpFileImmediately(const char* pHtml, const char* pCsv, void* 
 		MicroProfileFlip(pGpuContext);
 	}
 
+	std::lock_guard<std::recursive_mutex> Lock(MicroProfileMutex());
+
 	uint32_t nDumpMask = 0;
 	if(pHtml)
 	{
@@ -3161,16 +3163,15 @@ void MicroProfileDumpFileImmediately(const char* pHtml, const char* pCsv, void* 
 		memcpy(S.CsvDumpPath, pCsv, nLen+1);
 		nDumpMask |= 2;
 	}
-	std::lock_guard<std::recursive_mutex> Lock(MicroProfileMutex());
+
 	S.nDumpFileNextFrame = nDumpMask;
 	S.nDumpSpikeMask = 0;
 	S.nDumpFileCountDown = 0;
 
 	MicroProfileDumpToFile();
-
-
-
+	S.nDumpFileNextFrame = 0;
 }
+
 void MicroProfileDumpFile(const char* pHtml, const char* pCsv, float fCpuSpike, float fGpuSpike)
 {
 	S.fDumpCpuSpike = fCpuSpike;


### PR DESCRIPTION
Ensure that all changes to S.* values are synchronized
Reset S.nDumpFileNextFrame after call to MicroProfileDumpToFile()