### PR TITLE
Fix MicroProfileDumpFileImmediately to also reset counters and clean up MicroProfileDumpFile

### DIFF
--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -3168,12 +3168,13 @@ void MicroProfileDumpFileImmediately(const char* pHtml, const char* pCsv, void* 
 	S.nDumpSpikeMask = 0;
 	S.nDumpFileCountDown = 0;
 
-	MicroProfileDumpToFile();
-	S.nDumpFileNextFrame = 0;
+	// File written on next MicroProfileFlip() call
 }
 
 void MicroProfileDumpFile(const char* pHtml, const char* pCsv, float fCpuSpike, float fGpuSpike)
 {
+	std::lock_guard<std::recursive_mutex> Lock(MicroProfileMutex());
+
 	S.fDumpCpuSpike = fCpuSpike;
 	S.fDumpGpuSpike = fGpuSpike;
 	uint32_t nDumpMask = 0;
@@ -3205,12 +3206,11 @@ void MicroProfileDumpFile(const char* pHtml, const char* pCsv, float fCpuSpike, 
 	}
 	else
 	{
-		std::lock_guard<std::recursive_mutex> Lock(MicroProfileMutex());
 		S.nDumpFileNextFrame = nDumpMask;
 		S.nDumpSpikeMask = 0;
 		S.nDumpFileCountDown = 0;
 
-		MicroProfileDumpToFile();
+		// File written on next MicroProfileFlip() call
 	}
 }
 

--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -2334,8 +2334,6 @@ void MicroProfileFlip(void* pContext)
 		if(0 == S.nDumpFileCountDown)
 		{
 			MicroProfileDumpToFile();
-			S.nDumpFileNextFrame = 0;
-			S.nAutoClearFrames = MICROPROFILE_GPU_FRAME_DELAY + 3; //hide spike from dumping webpage
 		}
 		else
 		{
@@ -3168,7 +3166,7 @@ void MicroProfileDumpFileImmediately(const char* pHtml, const char* pCsv, void* 
 	S.nDumpSpikeMask = 0;
 	S.nDumpFileCountDown = 0;
 
-	// File written on next MicroProfileFlip() call
+	MicroProfileDumpToFile();
 }
 
 void MicroProfileDumpFile(const char* pHtml, const char* pCsv, float fCpuSpike, float fGpuSpike)
@@ -3210,7 +3208,7 @@ void MicroProfileDumpFile(const char* pHtml, const char* pCsv, float fCpuSpike, 
 		S.nDumpSpikeMask = 0;
 		S.nDumpFileCountDown = 0;
 
-		// File written on next MicroProfileFlip() call
+		MicroProfileDumpToFile();
 	}
 }
 
@@ -4104,6 +4102,8 @@ void MicroProfileDumpToFile()
 			fclose(F);
 		}
 	}
+	S.nDumpFileNextFrame = 0;
+	S.nAutoClearFrames = MICROPROFILE_GPU_FRAME_DELAY + 3; //hide spike from dumping webpage
 }
 
 void MicroProfileFlushSocket(MpSocket Socket)


### PR DESCRIPTION
In change to remove duplicate file writing, the first file write was chosen. The second happens to also reset the counters for microprofile. Consolidate post-file-dump logic to be consistent for all scenarios.

MicroProfileDumpFile did not synchronize variables properly. Clean this up and also remove its redundant file write.