### PR TITLE
Microprofiler Nonblocking OptName Fix

### DIFF
--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -5088,6 +5088,9 @@ void MicroProfileSetNonBlocking(MpSocket Socket, int NonBlocking)
 #ifdef _WIN32
 	u_long nonBlocking = NonBlocking ? 1 : 0; 
 	ioctlsocket(Socket, FIONBIO, &nonBlocking);
+#elif defined(PLATFORM_NONBLOCK_OPTNAME)
+	int on = NonBlocking ? 1 : 0;
+	setsockopt(Socket, SOL_SOCKET, PLATFORM_NONBLOCK_OPTNAME, (void*)&on, sizeof(on));
 #else
 	int Options = fcntl(Socket, F_GETFL);
 	if(NonBlocking)

--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -5088,9 +5088,9 @@ void MicroProfileSetNonBlocking(MpSocket Socket, int NonBlocking)
 #ifdef _WIN32
 	u_long nonBlocking = NonBlocking ? 1 : 0; 
 	ioctlsocket(Socket, FIONBIO, &nonBlocking);
-#elif defined(PLATFORM_NONBLOCK_OPTNAME)
+#elif defined(MICROPROFILE_SOCKET_NONBLOCK_OPTNAME)
 	int on = NonBlocking ? 1 : 0;
-	setsockopt(Socket, SOL_SOCKET, PLATFORM_NONBLOCK_OPTNAME, (void*)&on, sizeof(on));
+	setsockopt(Socket, SOL_SOCKET, MICROPROFILE_SOCKET_NONBLOCK_OPTNAME, (void*)&on, sizeof(on));
 #else
 	int Options = fcntl(Socket, F_GETFL);
 	if(NonBlocking)


### PR DESCRIPTION
Here are the necessary changes to unblock microprofiler for some platforms.

For some platforms,  the `O_NONBLOCK` flag with `fcntl` flow doesn't work. We have to use the platform specific optname to set the sockets to non blocking state.

We will be using the `PLATFORM_NONBLOCK_OPTNAME` macro for this purpose.