### PR TITLE
Bugfix 270664: [Crash] Game hit a microprofiler crash while soaking the game over the weekend

### DIFF
--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -2232,14 +2232,14 @@ inline void MicroProfileLogPutLeave(MicroProfileToken nToken_, uint64_t nTick, M
 	MP_ASSERT(pLog != 0); //this assert is hit if MicroProfileOnCreateThread is not called
 	MP_ASSERT(pLog->nActive);
 	uint64_t LE = MicroProfileMakeLogIndex(MP_LOG_LEAVE, nToken_, nTick);
-	uint32_t nPos = pLog->nPut.load(std::memory_order_relaxed);
+	uint32_t nPos = pLog->nPut.load(std::memory_order_seq_cst);
 	uint32_t nNextPos = (nPos + 1) % MICROPROFILE_BUFFER_SIZE;
 	uint32_t nStackPut = --(pLog->nStackPut);
-	uint32_t nGet = pLog->nGet.load(std::memory_order_acquire);
+	uint32_t nGet = pLog->nGet.load(std::memory_order_seq_cst);
 	MP_ASSERT(nStackPut < MICROPROFILE_STACK_MAX);
 	MP_ASSERT(nNextPos != nGet); //should never happen
 	pLog->Log[nPos] = LE;
-	pLog->nPut.store(nNextPos, std::memory_order_release);
+	pLog->nPut.store(nNextPos, std::memory_order_seq_cst);
 }
 
 inline void MicroProfileLogPutFence(MicroProfileThreadLog* pLog) {


### PR DESCRIPTION
Bug [270664](https://dev-mc.visualstudio.com/Minecraft/_workitems/edit/270664/)
This PR also fix [279559](https://dev-mc.visualstudio.com/Minecraft/_workitems/edit/279559/)

This fix changes memory_order to sequentially consistent ordering.
I checked nNextPos and nGet when it hit MP_ASSERT(nNextPos != nGet), and they were different. It looks update timing problem, so I changed memory_order to more strict one.