### PR TITLE
Allow microprofiler worker threads to roam all cores on Switch

### DIFF
--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -1201,10 +1201,10 @@ void MicroProfileThreadStart(MicroProfileThread* pThread, MicroProfileThreadFunc
     pthread_create(pThread, &Attr, Func, 0);
 
 	// BBI-NOTE: (jilitzky) Allow the microprofiler to roam all cores on Switch so that it doesn't get starved by the main thread on core 0
-#if defined(MICROPROFILER_NX)
+#if defined(MICROPROFILE_NX)
 	cpu_set_t cpuSet;
 	CPU_ZERO(&cpuSet);
-	constexpr size_t numCores = 3;
+	const size_t numCores = std::thread::hardware_concurrency();
 	for (size_t i = 0; i < numCores; i++)
 	{
 		CPU_SET(i, &cpuSet);


### PR DESCRIPTION
The Microprofiler kicks off worker threads such as `MicroProfile Socket Sender` and these threads can easily become starved when they are pinned into Core 0 because the main thread will always win in terms of priority. On Switch, new threads inherit the core affinity of the thread that created them so the workers were being assigned to Core 0 by default. I'm using the affinity calls in `pthread` to allow the worker threads to roam all cores so they can find windows to send their data to the browser.