### PR TITLE
Bugfix: Fix null crash when fopen returns nullptr

### DIFF
--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -4927,7 +4927,7 @@ class MicroProfileDeferredFileWriter {
 	}
 
 	void writeInternalToDisk() {
-		if (mData.size() > 0) {
+		if (mData.size() > 0 && mFile != nullptr) {
 			fwrite(mData.data(), mData.size(), 1, (FILE*)mFile);
 			mData.clear();
 		}
@@ -4963,8 +4963,10 @@ public:
 	MicroProfileWriteCallback getWriteCallback() const { return mWriteCallback; }
 
 	~MicroProfileDeferredFileWriter() {
-		writeInternalToDisk();
-		fclose(mFile);
+		if (mFile != nullptr) {
+			writeInternalToDisk();
+			fclose(mFile);
+		}
 	}
 };
 


### PR DESCRIPTION
Fix newly introduced crash that happens if fopen returns nullptr.

Issue introduced in this PR: https://github.com/Mojang/microprofile/pull/21

Example crash callstack: (the pointer passed into fclose was null)
```
ucrtbase!invoke_watson+0x18
ucrtbase!_invalid_parameter+0x12d
ucrtbase!invalid_parameter_noinfo+0x9
ucrtbase!fclose+0x3b208
MicroProfileDeferredFileWriter::~MicroProfileDeferredFileWriter+0x3f
MicroProfileDumpToFile+0xd6
MicroProfileDumpFileImmediately+0xef
