### PR TITLE
Add accessor for both time and count, and fix extra counts that overlap flip calls

### DIFF
--- a/microprofile.h
+++ b/microprofile.h
@@ -128,6 +128,7 @@ typedef uint16_t MicroProfileGroupId;
 #define MICROPROFILE_COUNTER_LOCAL_UPDATE_SET_ATOMIC(var) do{}while(0)
 
 #define MicroProfileGetTime(group, name) 0.f
+#define MicroProfileGetTimeAndCount(group, name, time, count) false
 #define MicroProfileOnThreadCreate(foo) do{}while(0)
 #define MicroProfileOnThreadExit() do{}while(0)
 #define MicroProfileFlip(pContext) do{}while(0)
@@ -522,6 +523,7 @@ MICROPROFILE_API int MicroProfileEnabled();
 MICROPROFILE_API void MicroProfileForceEnableGroup(const char* pGroup, MicroProfileTokenType Type);
 MICROPROFILE_API void MicroProfileForceDisableGroup(const char* pGroup, MicroProfileTokenType Type);
 MICROPROFILE_API float MicroProfileGetTime(const char* pGroup, const char* pName);
+MICROPROFILE_API bool MicroProfileGetTimeAndCount(const char* pGroup, const char* pName, float& timeMS, uint32_t& count);
 MICROPROFILE_API int MicroProfilePlatformMarkersGetEnabled(); //enable platform markers. disables microprofile markers
 MICROPROFILE_API void MicroProfilePlatformMarkersSetEnabled(int bEnabled); //enable platform markers. disables microprofile markers
 MICROPROFILE_API void MicroProfileContextSwitchSearch(uint32_t* pContextSwitchStart, uint32_t* pContextSwitchEnd, uint64_t nBaseTicksCpu, uint64_t nBaseTicksEndCpu);


### PR DESCRIPTION
- Disable a line that increments nCount for a frame timer that is active during a MicroProfileFlip. Now nCount is only incremented when a token exit (MP_LOG_LEAVE, due to calling MicroProfileLeave) is handled.
- Add MicroProfileGetTimeAndCount which returns time like MicroProfileGetTime, but also a uint32_t count and whether a token was found.

Before this change, a timing around a 5 second piece of code (at 60 fps) would show up (via MicroProfileGetTime and MicroProfileGetFrameCount) as 301 timings, which are ~16ms each.
After this change, that timing would show up as 1 5000ms event.

I checked the HTML view as well, and everything still seems to work fine both with or without this change. Zooming in on one frame in the middle of the above 5 second example would show ~16ms of time spent on 0 count, with NaN average time.

The thing motivating this change is that I optimized some code that happened frequently on a background thread, going from about 20 msec to 2 msec per call. The rate of calling that code didn't change, but the profiling stats of the 'before' code showed roughly twice as many call events as the 'after'. Since every 'before' call overlapped a MicroProfileFlip(), they were counted twice, and their average time was thus measured as roughly half what it should have been. After the change, both 'before' and 'after' profiling results had the same number of calls to the instrumented code.