### PR TITLE
microprofiler properly outputs csv dumps

### DIFF
--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -4992,7 +4992,7 @@ void MicroProfileDumpToFile()
 	}
 	if(S.nDumpFileNextFrame&2)
 	{
-		MicroProfileDeferredFileWriter deferredFileWriter(S.HtmlDumpPath);
+		MicroProfileDeferredFileWriter deferredFileWriter(S.CsvDumpPath);
 		if(deferredFileWriter.getHandle())
 		{
 			MicroProfileDumpCsv(deferredFileWriter.getWriteCallback(), deferredFileWriter.getHandle());


### PR DESCRIPTION
Fixed a bug where the microprofiler would create html dumps when you ask for a csv files. 