### PR TITLE
Bug 466583: Android callstacks in devicelog runs have many unsymbolicated frames

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 option(MP_HIDE_SYMBOLS "Toggle to hide LTO symbols" OFF)
+message("++++ MP_HIDE_SYMBOLS = ${MP_HIDE_SYMBOLS}")
 
 set(microprofile_source
   ${CMAKE_CURRENT_SOURCE_DIR}/microprofile.cpp
@@ -22,6 +23,7 @@ PRIVATE
 
 if(NOT MSVC)
   if(MP_HIDE_SYMBOLS)
+    message(FATAL_ERROR "++++ MP_HIDE_SYMBOLS = ${MP_HIDE_SYMBOLS}")
     target_compile_options(microprofile
     PRIVATE
       -fvisibility=hidden

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,13 +1,40 @@
+option(MP_HIDE_SYMBOLS "Toggle to hide LTO symbols" OFF)
 
 set(microprofile_source
-	${CMAKE_CURRENT_SOURCE_DIR}/microprofile.cpp
-	${CMAKE_CURRENT_SOURCE_DIR}/microprofile.h
-	${CMAKE_CURRENT_SOURCE_DIR}/microprofile_html.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/microprofile.cpp
+  ${CMAKE_CURRENT_SOURCE_DIR}/microprofile.h
+  ${CMAKE_CURRENT_SOURCE_DIR}/microprofile_html.h
 )
 
 set(CMAKE_POSITION_INDEPENDENT_CODE on)
 add_library(microprofile STATIC ${microprofile_source})
 set_property(TARGET microprofile PROPERTY CXX_STANDARD 11)
-target_compile_definitions(microprofile PRIVATE MICROPROFILE_USE_CONFIG=1)
-target_include_directories(microprofile PUBLIC ${CMAKE_CURRENT_SOURCE_DIR})
-target_link_libraries(microprofile PRIVATE profiler)
+
+target_compile_definitions(microprofile
+PRIVATE
+  MICROPROFILE_USE_CONFIG=1
+)
+
+target_compile_options(microprofile
+PRIVATE
+  ${disableWarning}
+)
+
+if(NOT MSVC)
+  if(MP_HIDE_SYMBOLS)
+    target_compile_options(microprofile
+    PRIVATE
+      -fvisibility=hidden
+    )
+  endif()
+endif()
+
+target_include_directories(microprofile
+PUBLIC
+  ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(microprofile
+PRIVATE
+  profiler
+)


### PR DESCRIPTION
Added an option to toggle symbol visibility on clang.