### PR TITLE
Replace strcasecmp with hash compare.

### DIFF
--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -25,6 +25,26 @@
 #include "Core/Debug/DebugUtils.h"
 #include "Platform/Threading/ThreadUtil.h"
 
+namespace {
+	inline uint64_t hashStr( const char* str )
+	{
+		if (str == nullptr || *str == '\0')
+		{
+			return 0;
+		}
+		uint64_t hash = 5381;
+		uint64_t c = (uint64_t)(*str);
+		do
+		{
+			hash = (hash << 5) - hash + (c + ((c >= 'A' && c <= 'Z') * 32));
+			str++;
+			c = (uint64_t)(*str);
+		} while ( c != '\0' );
+		return hash;
+	}
+}
+
+
 #define MICROPROFILE_MAX_COUNTERS 512
 #define MICROPROFILE_MAX_COUNTER_NAME_CHARS (MICROPROFILE_MAX_COUNTERS*16)
 #define MICROPROFILE_MAX_GROUP_INTS (MICROPROFILE_MAX_GROUPS/32)
@@ -437,6 +457,7 @@ struct MicroProfileCategory
 struct MicroProfileGroupInfo
 {
 	char pName[MICROPROFILE_NAME_MAX_LEN];
+	uint64_t nNameHash;
 	uint32_t nNameLen;
 	uint32_t nGroupIndex;
 	uint32_t nNumTimers;
@@ -449,6 +470,7 @@ struct MicroProfileGroupInfo
 struct MicroProfileTimerInfo
 {
 	MicroProfileToken nToken;
+	uint64_t nNameHash;
 	uint32_t nTimerIndex;
 	uint32_t nGroupIndex;
 	char pName[MICROPROFILE_NAME_MAX_LEN];
@@ -1894,10 +1916,12 @@ void MicroProfileInitThreadLog()
 
 MicroProfileToken MicroProfileFindTokenInternal(const char* pGroup, const char* pName, uint32_t& searchFrom)
 {
+	uint64_t const groupKey = hashStr(pGroup);
+	uint64_t const nameKey = hashStr(pName);
 	uint32_t searchTo = S.nTotalTimers.load(std::memory_order_acquire);
 	for (; searchFrom < searchTo; ++searchFrom)
 	{
-		if (!MP_STRCASECMP(pName, S.TimerInfo[searchFrom].pName) && !MP_STRCASECMP(pGroup, S.GroupInfo[S.TimerToGroup[searchFrom]].pName))
+		if (nameKey == S.TimerInfo[searchFrom].nNameHash && groupKey == S.GroupInfo[S.TimerToGroup[searchFrom]].nNameHash)
 		{
 			return S.TimerInfo[searchFrom].nToken;
 		}
@@ -1916,9 +1940,10 @@ MicroProfileToken MicroProfileFindToken(const char* pGroup, const char* pName) {
 
 uint16_t MicroProfileGetGroup(const char* pGroup, MicroProfileTokenType Type)
 {
+	uint64_t const groupKey = hashStr(pGroup);
 	for(uint32_t i = 0; i < S.nGroupCount; ++i)
 	{
-		if(!MP_STRCASECMP(pGroup, S.GroupInfo[i].pName))
+		if (groupKey == S.GroupInfo[i].nNameHash)
 		{
 			return i;
 		}
@@ -1929,6 +1954,7 @@ uint16_t MicroProfileGetGroup(const char* pGroup, MicroProfileTokenType Type)
 		nLen = MICROPROFILE_NAME_MAX_LEN-1;
 	memcpy(&S.GroupInfo[S.nGroupCount].pName[0], pGroup, nLen);
 	S.GroupInfo[S.nGroupCount].pName[nLen] = '\0';
+	S.GroupInfo[S.nGroupCount].nNameHash = hashStr(S.GroupInfo[S.nGroupCount].pName);
 	S.GroupInfo[S.nGroupCount].nNameLen = nLen;
 	S.GroupInfo[S.nGroupCount].nNumTimers = 0;
 	S.GroupInfo[S.nGroupCount].nGroupIndex = S.nGroupCount;
@@ -2018,9 +2044,10 @@ MicroProfileToken MicroProfileGetToken(const char* pGroup, const char* pName, ui
 	uint32_t nLen = (uint32_t)strlen(pName);
 	if(nLen > MICROPROFILE_NAME_MAX_LEN-1)
 		nLen = MICROPROFILE_NAME_MAX_LEN-1;
-	memcpy(&S.TimerInfo[nTimerIndex].pName, pName, nLen);
+	memcpy(&S.TimerInfo[nTimerIndex].pName[0], pName, nLen);
 	snprintf(&S.TimerInfo[nTimerIndex].pNameExt[0], sizeof(S.TimerInfo[nTimerIndex].pNameExt)-1, "%s %s", S.GroupInfo[nGroupIndex].pName, pName);
 	S.TimerInfo[nTimerIndex].pName[nLen] = '\0';
+	S.TimerInfo[nTimerIndex].nNameHash = hashStr(S.TimerInfo[nTimerIndex].pName);
 	S.TimerInfo[nTimerIndex].nNameLen = nLen;
 	S.TimerInfo[nTimerIndex].nColor = nColor&0xffffff;
 	S.TimerInfo[nTimerIndex].nGroupIndex = nGroupIndex;

--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -2,6 +2,11 @@
 #include "microprofile.h"
 #if MICROPROFILE_ENABLED
 
+#	if defined(_MSC_VER)
+#		pragma optimize("",off)
+#	elif defined(__clang__)
+#		pragma clang optimize off
+#	endif
 
 
 #include <thread>
@@ -28,16 +33,20 @@
 namespace {
 	inline uint64_t hashStr( const char* str )
 	{
-		uint64_t hash = 5381;
-		if (str != nullptr && *str == '\0')
+		uint64_t hash = 0;
+		if (str != nullptr)
 		{
-			uint64_t c = (uint64_t)(*str);
-			do
+			hash = 5381;
+			if (*str != '\0')
 			{
-				hash = (hash << 5) - hash + (c + ((c >= 'A' && c <= 'Z') * 32));
-				str++;
-				c = (uint64_t)(*str);
-			} while ( c != '\0' );
+				uint64_t c = (uint64_t)(*str);
+				do
+				{
+					hash = (hash << 5) - hash + (c + ((c >= 'A' && c <= 'Z') * 32));
+					str++;
+					c = (uint64_t)(*str);
+				} while (c != '\0');
+			}
 		}
 		return hash;
 	}

--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -2,13 +2,6 @@
 #include "microprofile.h"
 #if MICROPROFILE_ENABLED
 
-#	if defined(_MSC_VER)
-#		pragma optimize("",off)
-#	elif defined(__clang__)
-#		pragma clang optimize off
-#	endif
-
-
 #include <thread>
 #include <mutex>
 #include <atomic>

--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -28,18 +28,17 @@
 namespace {
 	inline uint64_t hashStr( const char* str )
 	{
-		if (str == nullptr || *str == '\0')
-		{
-			return 0;
-		}
 		uint64_t hash = 5381;
-		uint64_t c = (uint64_t)(*str);
-		do
+		if (str != nullptr && *str == '\0')
 		{
-			hash = (hash << 5) - hash + (c + ((c >= 'A' && c <= 'Z') * 32));
-			str++;
-			c = (uint64_t)(*str);
-		} while ( c != '\0' );
+			uint64_t c = (uint64_t)(*str);
+			do
+			{
+				hash = (hash << 5) - hash + (c + ((c >= 'A' && c <= 'Z') * 32));
+				str++;
+				c = (uint64_t)(*str);
+			} while ( c != '\0' );
+		}
 		return hash;
 	}
 }


### PR DESCRIPTION
## Description
When profiling with the Switch CPU profiler strcasecmp is using ~35% of CPU, strcasecmp was being used my Microprofile to fetch profile tokens. This PR replaces strcasecmp with a hash compare.

Before:
![image](https://user-images.githubusercontent.com/65258664/112217030-6eee2200-8bdf-11eb-9fd7-dccbb8753971.png)

After:
![image](https://user-images.githubusercontent.com/65258664/112217097-7f9e9800-8bdf-11eb-8c13-fb76a56e55c9.png)
