### PR TITLE
Microprofiler - Fixed DumpUtcCaptureTime having the wrong value on switch

### DIFF
--- a/microprofile.cpp
+++ b/microprofile.cpp
@@ -20,6 +20,11 @@
 #include <inttypes.h>
 #endif
 
+#if defined(MCPE_PLATFORM_NX)
+#include <nn/time/time_Api.h>
+#include <nn/time/time_StandardUserSystemClock.h>
+#endif
+
 #include "Core/Debug/DebugUtils.h"
 #include "Core/Memory/MemoryTracker.h"
 #include "Platform/Threading/ThreadUtil.h"
@@ -4214,7 +4219,12 @@ void MicroProfileDumpHtml(MicroProfileWriteCallback CB, void* Handle, uint64_t n
 	float fAggregateMs = fToMsCPU * (nTicks - S.nAggregateFlipTick);
 	MicroProfilePrintf(CB, Handle, "S.DumpHost = '%s';\n", pHost ? pHost : "");
 	time_t CaptureTime;
+#if defined(MCPE_PLATFORM_NX)
+	nn::time::SystemClockTraits::time_point tp = nn::time::StandardUserSystemClock::now();
+	CaptureTime = nn::time::StandardUserSystemClock::to_time_t(tp);
+#else
 	time(&CaptureTime);
+#endif
 	MicroProfilePrintf(CB, Handle, "S.DumpUtcCaptureTime = %ld;\n", CaptureTime);
 	MicroProfilePrintf(CB, Handle, "S.AggregateInfo = {'Frames':%d, 'Time':%f};\n", S.nAggregateFrames, fAggregateMs);
 


### PR DESCRIPTION

The Microprofile captures on switch had the wrong date and "captured x seconds ago" data. 

On other platforms it looks like this:

![image](https://user-images.githubusercontent.com/66968366/123344115-0416f480-d508-11eb-9c0d-d65494bf4a5b.png)

On Switch it was looking like this (see the weird date and x day ago):

![image](https://user-images.githubusercontent.com/66968366/123344185-2c9eee80-d508-11eb-8e7b-68e7fa8a40d7.png)

So that data is shown by the `microprofile_html.h`:

![image](https://user-images.githubusercontent.com/66968366/123344277-5fe17d80-d508-11eb-9647-14445388ccaa.png)

And it's calculated based on this `S.DumpUtcCaptureTime` variable which gets set in `microprofile.cpp` (`MicroProfileDumpHtml`) like this:

```
MicroProfilePrintf(CB, Handle, "S.DumpUtcCaptureTime = %ld;\n", CaptureTime);
```

The `CaptureTime` was calculated by doing `time(&CaptureTime);`, which was fine on other platforms. But on switch it had a weird value. I checked how the `Time.cpp` was doing and it was doing like this:

![image](https://user-images.githubusercontent.com/66968366/123344442-bbac0680-d508-11eb-9778-ee32f9392e9e.png)

 So I updated the microprofile code to do the same way and it worked. So it's showing the proper data now on switch:

 
![image](https://user-images.githubusercontent.com/66968366/123344532-e4cc9700-d508-11eb-86ef-413c90978433.png)

